### PR TITLE
feat: updated descriptions and links

### DIFF
--- a/src/app/core/components/footer/footer.component.html
+++ b/src/app/core/components/footer/footer.component.html
@@ -1,18 +1,24 @@
 <footer>
   <div class="footer-container">
     <section>
-      <h2>About Tact</h2>
+      <h2>Going places</h2>
       <ul>
         <li>
           <a [link]="LINKS.DOCS">
             <div inlineSVG="assets/images/icons/docs.svg"></div>
-            <span>Docs</span>
+            <span>Documentation</span>
           </a>
         </li>
         <li>
           <a [link]="LINKS.PLAYGROUND">
             <div inlineSVG="assets/images/icons/design.svg"></div>
-            <span>Tact-by-example</span>
+            <span>Tact by Example</span>
+          </a>
+        </li>
+        <li>
+          <a [link]="LINKS.IDE">
+            <div inlineSVG="assets/images/icons/design.svg"></div>
+            <span>Web IDE</span>
           </a>
         </li>
         <li>
@@ -25,6 +31,12 @@
           <a [link]="LINKS.TELEGRAM">
             <div inlineSVG="assets/images/icons/telegram.svg"></div>
             <span>Telegram group</span>
+          </a>
+        </li>
+        <li>
+          <a [link]="LINKS.KITCHEN">
+            <div inlineSVG="assets/images/icons/telegram.svg"></div>
+            <span>Tact Kitchen</span>
           </a>
         </li>
         <li>

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -6,6 +6,7 @@
     <a class="link" [link]="LINKS.DOCS">Docs</a>
     <a class="link" [link]="LINKS.GITHUB">Github</a>
     <a class="link" [link]="LINKS.TELEGRAM">Telegram</a>
+    <a class="link" [link]="LINKS.KITCHEN">Tact Kitchen</a>
     <a class="link" [link]="LINKS.TWITTER">X.com</a>
   </div>
   <button #burger class="burger" [class.burger_opened]="burgerOpened" (click)="burgerToggled()">
@@ -17,6 +18,7 @@
       <a [link]="LINKS.DOCS">Docs</a>
       <a [link]="LINKS.GITHUB">Github</a>
       <a [link]="LINKS.TELEGRAM">Telegram</a>
+      <a [link]="LINKS.KITCHEN">Tact Kitchen</a>
       <a [link]="LINKS.TWITTER">X.com</a>
     </div>
   </button>

--- a/src/app/core/constants/LINKS.ts
+++ b/src/app/core/constants/LINKS.ts
@@ -1,11 +1,14 @@
 export enum LINKS {
   DESIGN = 'https://github.com/tact-lang/docs/blob/main/tact-design.md',
   DOCS = 'https://docs.tact-lang.org',
+  DOCSSTART = 'https://docs.tact-lang.org/#start',
   PHILOSOPHY = 'https://github.com/tact-lang/tact#10-commandments-of-tact',
   GITHUB = 'https://github.com/tact-lang',
   TELEGRAM = 'https://t.me/tactlang',
+  KITCHEN = 'https://t.me/tact_kitchen',
   TON = 'https://ton.org/',
   TWITTER = 'http://twitter.com/tact_language',
   BRAND_ASSETS = 'https://drive.google.com/drive/folders/1Tg1aNg1VqcyiNk26V6IzcHYtsncQWahl?usp=drive_link',
-  PLAYGROUND = 'https://tact-by-example.org/all'
+  PLAYGROUND = 'https://tact-by-example.org/all',
+  IDE = 'https://ide.ton.org',
 }

--- a/src/app/features/main/components/labeled-editor/labeled-editor.component.html
+++ b/src/app/features/main/components/labeled-editor/labeled-editor.component.html
@@ -1,16 +1,17 @@
 <div class="editor-head">
   <div class="editor-head__title">
     <ng-container *ngIf="language === LANGUAGE.TACT; else funcTitle">Tact code</ng-container>
-    <ng-template #funcTitle>FunC result</ng-template>
+    <!-- NOTE: In the future, this shall be replaced with TVM instructions (disassembled, with comments about the stack) -->
+    <ng-template #funcTitle>FunC output</ng-template>
   </div>
-  <div class="editor-head__description">
+  <!-- <div class="editor-head__description">
     <ng-container *ngIf="language === LANGUAGE.TACT; else funcDescription">
       Write Tact code below
     </ng-container>
     <ng-template #funcDescription>
       Tact compiler will turn the program to FunC code on the fly
     </ng-template>
-  </div>
+  </div> -->
 </div>
 <div class="editor-wrapper">
   <app-editor

--- a/src/app/features/main/components/main-page-title/main-page-title.component.html
+++ b/src/app/features/main/components/main-page-title/main-page-title.component.html
@@ -1,6 +1,6 @@
 <section>
   <span class="tact-label">Tact</span>
   <span class="tact-description">
-    Unleashing ton’s power with safe and scalable smart contracts
+    Unleashing the power of TON with safe and scalable smart contracts
   </span>
 </section>

--- a/src/app/features/main/components/what-is-tact/what-is-tact.component.html
+++ b/src/app/features/main/components/what-is-tact/what-is-tact.component.html
@@ -2,16 +2,16 @@
     <h2 class="font-header tact-header">What is Tact?</h2>
     <article>
         <p>
-            Tact is a new programming language for TON blockchain that is focused on efficiency and simplicity. It is designed to be easy to learn and use, and to be a good fit for smart contracts. Tact is a statically typed language with a <a href="#familiar-syntax">simple syntax</a> and <a href="#type-system">powerful type system</a>.
+            Tact is a fresh programming language for TON Blockchain, focused on efficiency and ease of development. It is a good fit for complex smart contracts, quick onboarding and rapid prototyping. Tact is a statically typed language with a <a href="#familiar-syntax">simple syntax</a> and <a href="#type-system">powerful type system</a>.
         </p>
     </article>
     <article id="familiar-syntax">
         <h3>Familiar syntax</h3>
         <p>
-            Tact offers familiar syntax inspired by JavaScript & Typescript, Rust and Swift. Powerful features such as algebraic data types and compile-time execution look organic and friendly to new developers. 
+            Tact offers familiar syntax inspired by JavaScript & Typescript, Swift, Kotlin and Rust. Powerful features such as algebraic data types and compile-time execution look organic and friendly to new developers.
         </p>
         <app-code-snippet content='receive("increment") {
-    self.val = self.val + 1; 
+    self.val += 1;
 } 
 
 get fun value(input: Int): Int {
@@ -21,7 +21,7 @@ get fun value(input: Int): Int {
           maxWidth: 600,
           content:
             "receive(\"increment\") {\n" +
-            "    self.val = self.val + 1;\n" +
+            "    self.val += 1;\n" +
             "}\n\n" +
             "get fun value(input: Int): Int {\n" +
             "    return input + self.val;\n" +
@@ -71,12 +71,11 @@ get fun value(input: Int): Int {
     </article>
 
     <article>
-        <h3>Tact is just getting started</h3>
+        <h3>Bright future awaits</h3>
+        <p>Tact is developed in the open source and open development model on <a [link]="LINKS.GITHUB" class="inline-link">Github</a> — suggestions, issues and bug fixes are welcome. In addition, GitHub provides syntax highlighting for Tact code across the website.</p>
+        <p>Many Tact contracts have already been written and more and more projects are using Tact in production.</p>
         <p>
-            Tact is a very new project. It is not fully designed yet and ready to use <strong>at your own risk</strong>. We announce it early in order to collect the feedback and make it useful to developers incrementally.
-        </p>
-        <p>
-            To start, see the Getting Started section of <a [link]="LINKS.DOCS" class="inline-link">Docs</a>. Track our progress (and help with development) on <a [link]="LINKS.GITHUB" class="inline-link">Tact Github</a>.
+            To start writing ⚡ Tact yourself, see the <a [link]="LINKS.DOCSSTART" class="inline-link">Let's start</a> section on the main page of the <a [link]="LINKS.DOCS" class="inline-link">Tact Docs</a>. Good luck on your coding adventure!
         </p>
     </article>
 </section>

--- a/src/app/features/main/services/editor.service.ts
+++ b/src/app/features/main/services/editor.service.ts
@@ -24,7 +24,7 @@ const tactCodeExample =
   '}';
 
 const funCCodeExample =
-  'include "imports/stdlib.fc";\n' +
+  '#include "imports/stdlib.fc";\n' +
   '\n' +
 
   'int op::transfer_coins() asm "0x123123 PUSHINT";\n' +

--- a/src/app/shared/components/editor/editor.component.scss
+++ b/src/app/shared/components/editor/editor.component.scss
@@ -91,9 +91,13 @@ $numeric-color: #8c7aff;
       }
     }
 
-    .ace_comment {
+    .ace_string {
       color: $comment-color;
     }
+
+    /* .ace_comment {
+      color: $comment-color;
+    } */
 
     ::-webkit-scrollbar {
       background: none;

--- a/src/scripts/func-mode.js
+++ b/src/scripts/func-mode.js
@@ -71,6 +71,7 @@ ace.define(
         start: [
           { token: 'comment', regex: /;;[^\n\r]*/ },
           { token: 'comment', regex: /{-/, next: 'multiLineComment' },
+          { token: 'string', regex: /(?:(")(?:\\.|(?!\1)[^\\\r\n])*\1(?!\1))/ },
           { token: 'keyword', regex: `\\b(${funcKeywords.join('|')})\\b` },
           /*{ token: 'keyword', regex: /;/ },*/
           { token: 'keyword', regex: /~/ },

--- a/src/scripts/tact-mode.js
+++ b/src/scripts/tact-mode.js
@@ -8,7 +8,7 @@ ace.define(
     const TextMode = aceRequire('ace/mode/text').Mode;
     const TactHighlightRules = aceRequire('ace/mode/tact_highlight_rules').TactHighlightRules;
 
-    const Mode = function () {
+    const Mode = function() {
       this.HighlightRules = TactHighlightRules;
     };
 
@@ -23,33 +23,37 @@ ace.define(
   (aceRequire, exports) => {
     const oop = aceRequire('ace/lib/oop');
     const TextHighlightRules = aceRequire('ace/mode/text_highlight_rules').TextHighlightRules;
+    const hlNumeric = {
+      token: 'constant.numeric',
+      regex: /\b(?:0x[0-9a-fA-Z](?:_?[0-9a-fA-Z])*|0o[0-7](?:_?[0-7])*|0b[01](?:_?[01])*|0\d*|[1-9](?:_?\d)*)\b/,
+    };
 
+    // https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#commonTokens
+    // https://cloud9-sdk.readme.io/docs/highlighting-rules
+    // https://cloud9-sdk.readme.io/docs/import-a-textmate-theme
+    // NOTE:
+    // The names for the tokens misrepresent the syntax,
+    // but it all somewhat works because the color scheme is patched all over the place.
     const TactHighlightRules = function TactHighlightRules() {
       this.$rules = {
         start: [
           { token: 'comment', regex: /\/\/[^\n\r]*/ },
           { token: 'comment', regex: /\/\*/, next: 'multiLineComment' },
-          {
-            token: ['keyword', 'variable'],
-            regex: /(struct\s+)([\w]+)/
-          },
-          { token: 'text', regex: /\w+:\s*/, next: 'typeAnnotation' },
-          { token: 'keyword', regex: /struct\s*/, next: 'typeAnnotation' },
+          { token: 'string', regex: /(?:(")(?:\\.|(?!\1)[^\\\r\n])*\1(?!\1))/ },
+          { token: ['keyword', 'variable'], regex: /(struct\s+)([\w]+)/ },
+          { token: 'text', regex: /[{}[\]();,.:]/ },
           { token: 'keyword', regex: /\b(?:abstract|as|const|contract(?!:)|do|else|extend|extends|fun|get|if|import|initOf|inline|let|message(?!:)|mutates|native|override|primitive|public|repeat|return|self|struct(?!:)|trait(?!:)|until|virtual|while|with)\b/ },
-          {token: 'keyword', regex: /\b(?:init|receive|bounced|external)\b/},
+          { token: 'keyword', regex: /\b(?:init|receive|bounced|external)\b(?=\s*\()/ },
+          { token: 'variable', regex: /(?<=\bas\s+)(?:coins|remaining|bytes32|bytes64|int257|u?int(?:2[0-5][0-6]|1[0-9][0-9]|[1-9][0-9]?))\b/ },
+          { ...hlNumeric },
+          { token: 'keyword.operator', regex: /![!=]?|->|[+\-*/%=]=?|[<>]=|<<?|>>?|~|\|[\|=]?|&[&=]?|\^=?|\?/ },
           { token: ['constant', 'text'], regex: /\b([a-z]+[\w_]*\b)(\()/ },
           { token: ['variable'], regex: /\b[A-Z]+[\w_]*\b/ },
           { caseInsensitive: false },
-          
         ],
         multiLineComment: [
           { token: 'comment', regex: /\*\//, next: 'start' },
           { defaultToken: 'comment' }
-        ],
-        typeAnnotation: [
-          { token: 'text', regex: /\(/, next: 'genericCall' },
-          { token: 'text', regex: /[^\w]/, next: 'start' },
-          { defaultToken: 'variable' }
         ],
         genericCall: [
           { token: 'text', regex: /\(/, next: 'genericSubCall' },


### PR DESCRIPTION
And adjusted code highlighting a bit.

**Before:**

![code highlighting before the change](https://github.com/user-attachments/assets/0e08f431-005a-457c-bde3-460678201ded)

**After:**

![code highlighting after the change](https://github.com/user-attachments/assets/a11c7a0b-90c3-44c5-bf9b-c5dd32618896)

**Before:**

![code highlighting before the change](https://github.com/user-attachments/assets/359b6bf6-f94b-4477-8933-0254275e0fb2)

**After:**

![code highlighting after the change](https://github.com/user-attachments/assets/5918a94d-5461-4b40-a9f3-a7fe56a7df94)

The names for the tokens in highlighting misrepresent the syntax, but it all somewhat works because the color scheme is patched all over the place. While I'd like to rewrite everything and just use the TextMate grammars, the end user doesn't see this madness, so I've just tweaked the highlighting a little to make it look good enough.